### PR TITLE
Comment out the spell checker

### DIFF
--- a/src/js/simplemde.js
+++ b/src/js/simplemde.js
@@ -8,7 +8,7 @@ require("codemirror/mode/markdown/markdown.js");
 require("codemirror/addon/mode/overlay.js");
 require("codemirror/mode/gfm/gfm.js");
 require("codemirror/mode/xml/xml.js");
-require("spell-checker");
+// require("spell-checker");
 var marked = require("marked");
 
 


### PR DESCRIPTION
 To avoid dependency bug by using Node 3.0.0+ you need to remove spell-checker.
(Temp)
